### PR TITLE
chore: Use correct db port in devcontainer settings

### DIFF
--- a/.devcontainer/docker-compose.extend.yml
+++ b/.devcontainer/docker-compose.extend.yml
@@ -10,7 +10,7 @@ services:
             - /workspace/__pycache__
     db:
         ports:
-            - '3306'
+            - '5432'
     es:
         ports:
             - '9200'


### PR DESCRIPTION
Fixes #3737 