### PR TITLE
feat: add elasticsearch repository-azure plugin

### DIFF
--- a/k8s/elasticsearch.yaml
+++ b/k8s/elasticsearch.yaml
@@ -23,6 +23,18 @@ spec:
             privileged: true
             runAsUser: 0
           command: ['sh', '-c', 'sysctl -w vm.max_map_count=262144']
+        - name: install-plugins
+          image: docker.elastic.co/elasticsearch/elasticsearch:7.17.21
+          command:
+          - sh
+          - -c
+          - |
+            bin/elasticsearch-plugin install --batch repository-azure
+          volumeMounts:
+          - name: es-data
+            mountPath: /usr/share/elasticsearch/data
+          - name: es-plugins
+            mountPath: /usr/share/elasticsearch/plugins
       containers:
         - image: "docker.elastic.co/elasticsearch/elasticsearch:7.17.21"
           imagePullPolicy: IfNotPresent
@@ -34,6 +46,8 @@ spec:
           volumeMounts:
             - name: es-data
               mountPath: /usr/share/elasticsearch/data
+            - name: es-plugins
+              mountPath: /usr/share/elasticsearch/plugins
             - name: es-snapshots
               mountPath: /mnt/snapshots
           env:
@@ -69,6 +83,8 @@ spec:
       volumes:
         # To be overriden with the actual shared volume
         - name: es-snapshots
+        - name: es-plugins
+          emptyDir: {}
   volumeClaimTemplates:
   - metadata:
       name: es-data


### PR DESCRIPTION
The Azure Repository plugin adds support for using Azure Blob storage as a repository for Snapshot/Restore.

https://www.elastic.co/guide/en/elasticsearch/plugins/7.17/repository-azure.html
