### PR TITLE
fix: remove kibana service for now

### DIFF
--- a/k8s/kustomization.yaml
+++ b/k8s/kustomization.yaml
@@ -13,4 +13,4 @@ resources:
   - mailarchive.yaml
   - memcached.yaml
   - rabbitmq.yaml
-  - kibana.yaml
+  # - kibana.yaml


### PR DESCRIPTION
Refocusing effort on adding support for Typesense rather than doing work on upgrades of Elasticsearch version. Kibana was added to aid the upgrades. Commenting out now to simplify production Kubernetes setup.