### PR TITLE
fix: use 127.0.0.1 to prevent intermittent ipv6 connection refused

### DIFF
--- a/k8s/nginx-mailarchive.conf
+++ b/k8s/nginx-mailarchive.conf
@@ -20,7 +20,7 @@ server {
         proxy_set_header Connection close;
         proxy_set_header X-Request-Start "t=$${keepempty}msec";
         proxy_set_header X-Forwarded-For $${keepempty}proxy_add_x_forwarded_for;
-        proxy_pass http://localhost:8000;
+        proxy_pass http://127.0.0.1:8000;
         # Set timeouts longer than Cloudflare proxy limits
         proxy_connect_timeout 60;  # nginx default (Cf = 15)
         proxy_read_timeout 120;  # nginx default = 60 (Cf = 100) 


### PR DESCRIPTION
Using the nginx setting "proxy_pass http://localhost:8000" results in nginx attempting to connect to gunicorn app server over ipv6 and timing out, spamming log with errors:

 connect() failed (111: Connection refused) while connecting to upstream, client: 10.244.11.165, server: _, request: "GET /favicon.ico HTTP/1.1", upstream: "http://[::1]:8000/favicon.ico", host: "mailarchive.ietf.org", referrer: "https://mailarchive.ietf.org/arch/export/url/?...

Change to http://127.0.0.1:8000 to specify ipv4.