### PR TITLE
fix: fix missing attachments. Fixes #4210

### DIFF
--- a/backend/mlarchive/archive/mail.py
+++ b/backend/mlarchive/archive/mail.py
@@ -26,6 +26,7 @@ from django.core.cache import cache
 from mlarchive.archive.models import (Attachment, EmailList, Legacy, Message,
     Thread, get_in_reply_to_message, is_attachment)
 from mlarchive.archive.management.commands._mimetypes import CONTENT_TYPES, UNKNOWN_CONTENT_TYPE
+from mlarchive.archive.message_json import write_message_json
 from mlarchive.archive.inspectors import *      # noqa
 from mlarchive.archive.storage_utils import store_file
 from mlarchive.archive.thread import compute_thread, reconcile_thread, parse_message_ids
@@ -1017,8 +1018,11 @@ class MessageWrapper(object):
                     self.listname, self.msgid, self.hashcode))
 
     def save(self, test=False):
-        """Run message checks (spam, duplicate, etc).  Save message metadata
-        to database. Save message to archive (if not test mode) and process attachments.
+        """Save the message to the archive.
+
+        Runs the message checks (spam, duplicate, etc), saves message metadata
+        to database, saves message to archive, processes attachments and writes
+        the JSON blob.  In test mode the message and JSON blobs are not written.
         """
         self.run_inspectors()
 
@@ -1045,6 +1049,11 @@ class MessageWrapper(object):
 
         # now that the archive.Message object is created we can process any attachments
         self.process_attachments(test=test)
+
+        # write the JSON blob last.  It contains the rendered message body,
+        # which includes links to the attachments created above
+        if not test:
+            write_message_json(self.archive_message)
 
     def write_msg(self, subdir=None):
         """Write a copy of the original email message to the disk archive.

--- a/backend/mlarchive/archive/message_json.py
+++ b/backend/mlarchive/archive/message_json.py
@@ -1,0 +1,63 @@
+# Copyright The IETF Trust 2026, All Rights Reserved
+
+"""Write the ml-messages-json blobs used by the Cloudflare worker.
+
+These are written once the message is fully archived, not from a Message
+post_save signal, because the serialized JSON includes the rendered message
+body, which links to the message's Attachment records.  Those records can only
+be created after the Message has a primary key, ie. after post_save has run.
+See MessageWrapper.save().
+"""
+
+import io
+import logging
+
+from mlarchive.archive.storage_utils import store_file
+
+logger = logging.getLogger(__name__)
+
+
+def store_message_json(message):
+    """Write the ml-messages-json blob for one message."""
+    store_file(
+        kind='ml-messages-json',
+        name=message.get_blob_name(),
+        file=io.BytesIO(message.as_json().encode('utf-8')),
+        allow_overwrite=True,
+        content_type='application/json'
+    )
+
+
+def write_message_json(message):
+    """Write the JSON blobs affected by a newly archived message.
+
+    Writes the blob for the message itself, then refreshes the blobs of the
+    neighboring messages whose navigation links the new message invalidates.
+    Private messages have no JSON blob.
+    """
+    if message.email_list.private:
+        return
+    store_message_json(message)
+    if message.thread_order > 0:
+        update_message_json_thread(message)
+    update_message_json_list(message)
+
+
+def update_message_json_thread(message):
+    """Write ml-messages-json for all other messages in thread.
+
+    TODO: consider alternatives like client retrieving thread instead of
+    computing
+    """
+    for msg in message.thread.message_set.exclude(pk=message.pk):
+        store_message_json(msg)
+
+
+def update_message_json_list(message):
+    """Write ml-messages-json for the previous message in list order.
+
+    Its next_in_list link becomes stale when a new message is added after it.
+    """
+    prev_msg = message.previous_in_list()
+    if prev_msg:
+        store_message_json(prev_msg)

--- a/backend/mlarchive/archive/signals.py
+++ b/backend/mlarchive/archive/signals.py
@@ -1,4 +1,3 @@
-import io
 import logging
 import os
 import requests
@@ -18,7 +17,7 @@ from django.db import models, connection, transaction
 
 from mlarchive.archive.models import Message, EmailList
 from mlarchive.archive.backends.elasticsearch import ESBackend, get_identifier
-from mlarchive.archive.storage_utils import store_file, remove_from_storage, move_object
+from mlarchive.archive.storage_utils import remove_from_storage, move_object
 from mlarchive.archive.utils import _export_lists
 from mlarchive.celeryapp import app
 
@@ -28,22 +27,6 @@ logger = logging.getLogger(__name__)
 # --------------------------------------------------
 # Signal Handlers
 # --------------------------------------------------
-
-@receiver(post_save, sender=Message)
-def _save_message_json(sender, instance, created, **kwargs):
-    '''Save ml-messages-json blob for use in Cloudflare worker edge response'''
-    if not instance.email_list.private and created:
-        store_file(
-            kind='ml-messages-json',
-            name=instance.get_blob_name(),
-            file=io.BytesIO(instance.as_json().encode('utf-8')),
-            allow_overwrite=True,
-            content_type='application/json'
-        )
-        if instance.thread_order > 0:
-            update_message_json_thread(instance)
-        update_message_json_list(instance)
-
 
 @receiver([post_save, post_delete], sender=EmailList)
 def _clear_lists_cache(sender, instance, **kwargs):
@@ -186,34 +169,6 @@ def _flush_noauth_cache(email_list):
     keys = ['{:04d}-noauth'.format(user.id) for user in email_list.members.all()]
     cache.delete_many(keys)
 
-
-def update_message_json_thread(message):
-    '''Write ml-messages-json for all other messages in thread
-    TODO: consider alternatives like client retrieving thread instead of computing
-    '''
-    for msg in message.thread.message_set.exclude(pk=message.pk):
-        store_file(
-            kind='ml-messages-json',
-            name=msg.get_blob_name(),
-            file=io.BytesIO(msg.as_json().encode('utf-8')),
-            allow_overwrite=True,
-            content_type='application/json'
-        )
-
-
-def update_message_json_list(message):
-    '''Write ml-messages-json for the previous message in list order.
-    Its next_in_list link becomes stale when a new message is added after it.
-    '''
-    prev_msg = message.previous_in_list()
-    if prev_msg:
-        store_file(
-            kind='ml-messages-json',
-            name=prev_msg.get_blob_name(),
-            file=io.BytesIO(prev_msg.as_json().encode('utf-8')),
-            allow_overwrite=True,
-            content_type='application/json'
-        )
 
 # --------------------------------------------------
 # Classes

--- a/backend/mlarchive/tests/archive/mail.py
+++ b/backend/mlarchive/tests/archive/mail.py
@@ -2,6 +2,7 @@
 import datetime
 import email
 import email.message
+import json
 from email import policy
 import glob
 import io
@@ -91,6 +92,68 @@ This is a test email.  database
     # test that thread date is correct in index
     url = reverse('archive_search') + '?q=tdate:20131107175455'
     assert len(response.context['results']) == 1
+
+
+@pytest.mark.django_db(transaction=True)
+def test_archive_message_json_attachments():
+    """Test the JSON blob body includes links to the attachments.
+
+    The ml-messages-json blob contains the rendered message body, which
+    includes links to the message's attachments, so it must be written after
+    the Attachment records are created.  See MessageWrapper.save().
+    """
+    path = os.path.join(settings.BASE_DIR, 'tests', 'data', 'attachment.mail')
+    with open(path, 'rb') as f:
+        data = f.read()
+    assert archive_message(data, 'test', private=False) == 0
+    message = Message.objects.get()
+    assert message.attachment_set.count() == 1
+    attachment = message.attachment_set.first()
+    msg_json = json.loads(retrieve_str('ml-messages-json', message.get_blob_name()))
+    assert attachment.name in msg_json['body']
+    assert attachment.get_absolute_url() in msg_json['body']
+
+
+@pytest.mark.django_db(transaction=True)
+def test_archive_message_json_neighbors():
+    """Test a new message refreshes the JSON blobs of its neighbors.
+
+    A new message invalidates the navigation links of its thread siblings and
+    of the message before it in list order, so their JSON blobs are rewritten
+    too.  See write_message_json().
+
+    The third message replies to the first, but follows the second in list
+    order, so each of the two refresh paths updates a different blob.
+    """
+    def make(msgid, subject, day, in_reply_to=None):
+        headers = ['From: Joe <joe@example.com>',
+                   'To: list@example.com',
+                   f'Date: Thu, {day} Nov 2013 17:54:55 +0000',
+                   f'Message-ID: <{msgid}>',
+                   f'Subject: {subject}']
+        if in_reply_to:
+            headers.append(f'In-Reply-To: <{in_reply_to}>')
+            headers.append(f'References: <{in_reply_to}>')
+        return ('\n'.join(headers) + '\n\nbody\n').encode('ASCII')
+
+    def get_json(message):
+        return json.loads(retrieve_str('ml-messages-json', message.get_blob_name()))
+
+    assert archive_message(make('one@example.com', 'First', 7), 'test') == 0
+    assert archive_message(make('two@example.com', 'Second', 8), 'test') == 0
+    assert archive_message(
+        make('three@example.com', 'Re: First', 9, in_reply_to='one@example.com'), 'test') == 0
+
+    first = Message.objects.get(msgid='one@example.com')
+    second = Message.objects.get(msgid='two@example.com')
+    third = Message.objects.get(msgid='three@example.com')
+    assert third.thread == first.thread
+    assert third.thread_order > 0
+
+    # thread sibling refreshed, though it is not the previous message in list order
+    assert get_json(first)['next_in_thread'] == third.get_absolute_url()
+    # previous message in list order refreshed, though it is in another thread
+    assert get_json(second)['next_in_list'] == third.get_absolute_url()
 
 
 @pytest.mark.django_db(transaction=True)

--- a/backend/mlarchive/tests/archive/utils.py
+++ b/backend/mlarchive/tests/archive/utils.py
@@ -732,20 +732,18 @@ def test_rebuild_json_blobs():
     messages = [msg1, msg2]
     names = [m.get_blob_name() for m in messages]
 
-    # signal creates JSON blobs on message save
-    assert Blob.objects.filter(bucket='ml-messages-json', name__in=names).count() == 2
+    # JSON blobs are written by MessageWrapper.save(), not on Message save,
+    # so messages created directly have none
+    assert Blob.objects.filter(bucket='ml-messages-json', name__in=names).count() == 0
 
-    # update path: existing blobs get re-written
+    # create path: missing blobs get created
     with patch('mlarchive.archive.utils.replicate_batch', return_value=[]):
         failures = rebuild_json_blobs(messages)
 
     assert failures == []
     assert Blob.objects.filter(bucket='ml-messages-json', name__in=names).count() == 2
 
-    # create path: a missing blob is re-created
-    Blob.objects.get(bucket='ml-messages-json', name=names[0]).delete()
-    assert Blob.objects.filter(bucket='ml-messages-json', name__in=names).count() == 1
-
+    # update path: existing blobs get re-written
     with patch('mlarchive.archive.utils.replicate_batch', return_value=[]):
         failures = rebuild_json_blobs(messages)
 


### PR DESCRIPTION
When processing new message imports Attachments were created after ml-messages-json was written so it didn't include the attachment links