### PR TITLE
feat: allow multiple app apikeys per endpoint

### DIFF
--- a/backend/mlarchive/settings/base.py
+++ b/backend/mlarchive/settings/base.py
@@ -5,6 +5,7 @@ Using django-environ
 https://github.com/joke2k/django-environ
 """
 
+import base64
 import json
 import os
 import sys
@@ -18,6 +19,17 @@ from mlarchive import __version__, __release_hash__
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 ROOT_DIR = os.path.dirname(os.path.dirname(BASE_DIR))
+
+
+# default api keys for reference only
+_default_api_keys = {
+    '/api/v1/message/import/': [],
+    '/api/v1/message/import-mbox/': [],
+    '/api/v1/message/search/': [],
+}
+_api_keys_json_str = json.dumps(_default_api_keys)
+_api_keys_b64_bytes = base64.b64encode(_api_keys_json_str.encode('utf-8'))
+_api_keys_b64_string = _api_keys_b64_bytes.decode('utf-8')
 
 env = environ.Env(
     # set casting, default value
@@ -67,13 +79,11 @@ env = environ.Env(
     ELASTICSEARCH_SIGNAL_PROCESSOR=(str, 'mlarchive.archive.signals.CelerySignalProcessor'),
     EXPORT_LIMIT=(int, 5000),
     HTAUTH_PASSWD_FILENAME=(str, ''),
-    IMPORT_MESSAGE_APIKEY=(str, ''),
-    IMPORT_MBOX_APIKEY=(str, ''),
-    SEARCH_MESSAGE_APIKEY=(str, 'changeme'),
     INTERNAL_IPS=(list, []),
     LOG_DIR=(str, '/var/log/mail-archive'),
     LOG_HANDLERS=(list, ['mlarchive']),
     LOG_LEVEL=(str, 'INFO'),
+    MAILARCHIVE_APP_API_KEYS_JSON_B64=(str, _api_keys_b64_string),
     MAILMAN_API_PASSWORD=(str, ''),
     MAILMAN_API_URL=(str, 'https://mailman-api.ietf.org/3.1'),
     MAILMAN_API_USER=(str, ''),
@@ -445,19 +455,15 @@ MAILMAN_API_USER = env('MAILMAN_API_USER')
 MAILMAN_API_PASSWORD = env('MAILMAN_API_PASSWORD')
 MAILMAN_CF_ACCESS_CLIENT_ID = env('MAILMAN_CF_ACCESS_CLIENT_ID')
 MAILMAN_CF_ACCESS_CLIENT_SECRET = env('MAILMAN_CF_ACCESS_CLIENT_SECRET')
-IMPORT_MESSAGE_APIKEY = env('IMPORT_MESSAGE_APIKEY')
-IMPORT_MBOX_APIKEY = env('IMPORT_MBOX_APIKEY')
 
 # admin import mbox settings
 IMPORT_MBOX_MAX_SIZE = 1_800_000_000  # 1.8 GB
 
 # API KEYS: key=endpoint, value=[api-key,]
-SEARCH_MESSAGE_APIKEY = env('SEARCH_MESSAGE_APIKEY')
-API_KEYS = {
-    '/api/v1/message/import/': [IMPORT_MESSAGE_APIKEY],
-    '/api/v1/message/import-mbox/': [IMPORT_MBOX_APIKEY],
-    '/api/v1/message/search/': [SEARCH_MESSAGE_APIKEY],
-}
+_APP_API_KEYS_JSON = base64.b64decode(
+    env('MAILARCHIVE_APP_API_KEYS_JSON_B64')
+)
+MAILARCHIVE_APP_API_KEYS = json.loads(_APP_API_KEYS_JSON)
 
 # Default timeout for HTTP requests via the requests library
 DEFAULT_REQUESTS_TIMEOUT = 20  # seconds

--- a/backend/mlarchive/tests/archive/api.py
+++ b/backend/mlarchive/tests/archive/api.py
@@ -208,7 +208,7 @@ def get_error_message(response):
 def test_import_message(client, settings):
     settings.CELERY_TASK_ALWAYS_EAGER = True
     url = reverse('api_import_message')
-    settings.API_KEYS = {url: 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {url: 'valid_token'}
     path = os.path.join(settings.BASE_DIR, 'tests', 'data', 'mail.1')
     with open(path, 'rb') as f:
         message = f.read()
@@ -272,7 +272,7 @@ def test_import_message_private(client, settings):
     '''Ensure list_type variable is respected'''
     settings.CELERY_TASK_ALWAYS_EAGER = True
     url = reverse('api_import_message')
-    settings.API_KEYS = {url: 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {url: 'valid_token'}
     path = os.path.join(settings.BASE_DIR, 'tests', 'data', 'mail.1')
     with open(path, 'rb') as f:
         message = f.read()
@@ -301,7 +301,7 @@ def test_import_message_integration(client, settings):
     # skip sending task to broker and execute immediately
     settings.CELERY_TASK_ALWAYS_EAGER = True
     url = reverse('api_import_message')
-    settings.API_KEYS = {url: 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {url: 'valid_token'}
     path = os.path.join(settings.BASE_DIR, 'tests', 'data', 'mail.1')
     with open(path, 'rb') as f:
         message = f.read()
@@ -356,7 +356,7 @@ def test_msg_search(client, search_api_messages, settings):
     print('indexed items: {}'.format(len(response.hits)))
     # ---------------------------------------
     url = reverse('api_search_message')
-    settings.API_KEYS = {url: 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {url: 'valid_token'}
     data = {
         'email_list': 'acme',
         'query': 'bananas'
@@ -406,7 +406,7 @@ def test_msg_search(client, search_api_messages, settings):
 @pytest.mark.django_db(transaction=True)
 def test_msg_search_private(client, search_api_messages, settings):
     url = reverse('api_search_message')
-    settings.API_KEYS = {url: 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {url: 'valid_token'}
     acme = EmailList.objects.get(name='acme')
     acme.private = True
     acme.save()
@@ -429,7 +429,7 @@ def test_msg_search_private(client, search_api_messages, settings):
 @pytest.mark.django_db(transaction=True)
 def test_msg_search_start_date(client, search_api_messages, settings):
     url = reverse('api_search_message')
-    settings.API_KEYS = {url: 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {url: 'valid_token'}
     data = {
         'email_list': 'acme',
         'start_date': '2013-06-01',
@@ -460,7 +460,7 @@ def test_msg_search_start_date(client, search_api_messages, settings):
 @pytest.mark.django_db(transaction=True)
 def test_msg_search_query(client, search_api_messages, settings):
     url = reverse('api_search_message')
-    settings.API_KEYS = {url: 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {url: 'valid_token'}
     # field query
     data = {
         'email_list': 'acme',
@@ -521,7 +521,7 @@ def _make_mock_response(content, content_type='application/mbox'):
 @pytest.mark.django_db(transaction=True)
 def test_import_mbox_no_api_key(client, settings):
     url = reverse('api_import_mbox')
-    settings.API_KEYS = {url: 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {url: 'valid_token'}
     response = client.post(
         url,
         {'list_name': 'ancp', 'list_visibility': 'public', 'url': 'https://example.com/mbox'},
@@ -533,7 +533,7 @@ def test_import_mbox_no_api_key(client, settings):
 @pytest.mark.django_db(transaction=True)
 def test_import_mbox_invalid_api_key(client, settings):
     url = reverse('api_import_mbox')
-    settings.API_KEYS = {url: 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {url: 'valid_token'}
     response = client.post(
         url,
         {'list_name': 'ancp', 'list_visibility': 'public', 'url': 'https://example.com/mbox'},
@@ -545,7 +545,7 @@ def test_import_mbox_invalid_api_key(client, settings):
 @pytest.mark.django_db(transaction=True)
 def test_import_mbox_wrong_content_type(client, settings):
     url = reverse('api_import_mbox')
-    settings.API_KEYS = {url: 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {url: 'valid_token'}
     response = client.post(
         url,
         'list_name=ancp&list_visibility=public&url=https://example.com/mbox',
@@ -557,7 +557,7 @@ def test_import_mbox_wrong_content_type(client, settings):
 @pytest.mark.django_db(transaction=True)
 def test_import_mbox_missing_field(client, settings):
     url = reverse('api_import_mbox')
-    settings.API_KEYS = {url: 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {url: 'valid_token'}
     # missing url
     response = client.post(
         url,
@@ -570,7 +570,7 @@ def test_import_mbox_missing_field(client, settings):
 @pytest.mark.django_db(transaction=True)
 def test_import_mbox_invalid_visibility(client, settings):
     url = reverse('api_import_mbox')
-    settings.API_KEYS = {url: 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {url: 'valid_token'}
     response = client.post(
         url,
         {'list_name': 'ancp', 'list_visibility': 'open', 'url': 'https://example.com/mbox'},
@@ -582,7 +582,7 @@ def test_import_mbox_invalid_visibility(client, settings):
 @pytest.mark.django_db(transaction=True)
 def test_import_mbox_queues_task(client, settings):
     url = reverse('api_import_mbox')
-    settings.API_KEYS = {url: 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {url: 'valid_token'}
 
     with patch('mlarchive.archive.api.import_mbox_url_task') as mock_task:
         response = client.post(

--- a/backend/mlarchive/tests/utils/decorators.py
+++ b/backend/mlarchive/tests/utils/decorators.py
@@ -39,14 +39,14 @@ def test_check_list_access_ok():
 
 
 def test_is_valid_token(settings):
-    settings.API_KEYS = {'/api/v1/message/import/': 'valid_token'}
+    settings.MAILARCHIVE_APP_API_KEYS = {'/api/v1/message/import/': 'valid_token'}
     assert is_valid_token('/api/v1/message/import/', 'valid_token') is True
     assert is_valid_token('/api/v1/message/import/', 'invvalid_token') is False
     assert is_valid_token('/api/v1/different/endpoint/', 'valid_token') is False
 
 
 def test_require_api_key(settings):
-    settings.API_KEYS = {'/api/v1/message/import/': 'abcdefg'}
+    settings.MAILARCHIVE_APP_API_KEYS = {'/api/v1/message/import/': 'abcdefg'}
     rf = RequestFactory()
     func = Mock()
     rsp = HttpResponse()

--- a/backend/mlarchive/utils/decorators.py
+++ b/backend/mlarchive/utils/decorators.py
@@ -172,8 +172,8 @@ def staff_only(function):
 
 
 def is_valid_token(endpoint, token):
-    if hasattr(settings, "API_KEYS"):
-        token_store = settings.API_KEYS
+    if hasattr(settings, "MAILARCHIVE_APP_API_KEYS"):
+        token_store = settings.MAILARCHIVE_APP_API_KEYS
         if endpoint in token_store:
             endpoint_tokens = token_store[endpoint]
             # Be sure endpoints is a list or tuple so we don't accidentally use substring matching!


### PR DESCRIPTION
Instead of storing each endpoint api key in their own environment variable store the api key dictionary as json b64 encoded.